### PR TITLE
init.pp: install_from pip access rights are too restrictive

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,6 +174,7 @@ class puppetboard (
         ensure  => directory,
         recurse => true,
         force   => true,
+        mode   => '0755',
         purge   => true, # such cleanup is needed in case of a switch from install_from=vcsrepo to install_from=pip
       }
 


### PR DESCRIPTION
init.pp: in case of install_from pip access rights to ${basedir}/puppetboard are too restrictive

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

In case I install_from pip the access rights of the directory `${basedir}/puppetboard` might be too restrictive (in my case: user+group were root, and access rights for others were not available). So these rights need to be set explicitly, which this patch does.
